### PR TITLE
Fix the README.md in the software directory

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -5,11 +5,8 @@
 `clock_setup` : A module to set up the PLL chip on the board. Requires an
 additional compatible FTDI adapter.
 
-`clock_setup` : An Arduino project quickly set up to program boards compatible
-to the Arduino IDE.
-
-`clock_setup` : An Arduino project quickly set up to program boards compatible
-to the Arduino IDE.
+`clock_setup_using_arduino_code/clock_setup` : An Arduino project quickly set
+up to flash a firmware for configuring the PLL chip to compatible microcontrollers. 
 
 `modules` : Different modules needed for the main script.
 


### PR DESCRIPTION
This is just a small fix for `software/README.md` removing a redundant line and fixing and improving the exlanation for the arduino project directory. Thanks @usman1515 for pointing this out!