### PR TITLE
Add a checklist for the board setup

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,3 +2,7 @@
 
 Here are all files related to the documentation.
 The `img` directory contains all images used for the documentation.
+
+`setup_checklist.md` is a checklist for setting up the board, either a
+completely fresh one or one that already has the correct firmware for your
+chip.

--- a/doc/setup_checklist.md
+++ b/doc/setup_checklist.md
@@ -1,0 +1,37 @@
+# Board Setup Checklist
+
+This is a checklist containing all things that turned out to be important during
+the chip bring-up and testing, even though some steps seem trivial. The first
+group only has to be checked if the correct firmware has not been flashed to the 
+board and can be skipped otherwise. Feel free to extend this list if you find
+more things to be considered.
+
+## Flashing the Firmware
+- Change the chip (if another one should be used/tested)
+- Use the correct `gpio_config_io.py`
+- Use the correct firmware
+- Use the correct `PART` when flashing the firmware
+- Use the correct `SHUTTLE` (currently `MPW2` and `MPW5` are supported) when flashing the firmware
+- Flash the firmware
+
+## Uploading a User Design
+- Check the top wrapper
+- Check the user design for bugs
+- The `oeb` value should be set to `1` for outputs and `0` for inputs per pin
+- Create the bitstream
+- Use correct bitstream (link to correct file or select correct file)
+- Check for the clock
+- Check the baud rate
+- Upload the bitstream
+  -  for MPW-5: unplug the board and directly reconnect it (due to `oeb`
+  misconfiguration in the fabric itself and the type of hold time violation at
+  these pins)
+
+## Setting the Jumpers
+If the jumpers on your board are not set already, set them as follows:
+- `J6`: Connect eFPGA Rx and FTDI Tx
+- `J5`: Set for uploading a bitstream, unset for uploading the Caravel firmware
+- `J8`: Set the desired clock output of the PLL
+- `J4`: Set the desired Voltage
+- `J11` and `J13` set the desired internal clock
+- `J2` and `J3`: Connect `mprj_io[36]/[37]` either to the Bitbang inputs of the fabric or to pins `22`/`23` of `J7`, depending on your use case (most likely you want to use `22`/`23`)

--- a/doc/setup_checklist.md
+++ b/doc/setup_checklist.md
@@ -5,6 +5,7 @@ the chip bring-up and testing, even though some steps seem trivial. The first
 group only has to be checked if the correct firmware has not been flashed to the 
 board and can be skipped otherwise. Feel free to extend this list if you find
 more things to be considered.
+For flashing the firmware, refer to [this repository](https://github.com/IAmMarcelJung/fabulous-mpw-bringup).
 
 ## Flashing the Firmware
 - Change the chip (if another one should be used/tested)

--- a/software/README.md
+++ b/software/README.md
@@ -35,7 +35,7 @@ board.py [-h] [-i DEVICE_ID] [-v] {config_clocks,upload} ...
 Below, the main use cases are given as examples. By default, devices with the VID
 `0403` and PID `6014` and a baud rate of 57600 are used.
 
-> [!IMPORTANT]:
+> [!IMPORTANT]
 > Make sure to adjust the files to your local files.
 
 

--- a/software/README.md
+++ b/software/README.md
@@ -8,6 +8,13 @@ additional compatible FTDI adapter.
 `clock_setup_using_arduino_code/clock_setup` : An Arduino project quickly set
 up to flash a firmware for configuring the PLL chip to compatible microcontrollers. 
 
+`fabrics`: Files for the MPW-2 and MPW-5 fabrics. These include the following
+for the respective fabric:
+  - The `csv` file
+  - The top wrapper (essentially the constraints file)
+  - An example bitstream (has to be updated, and the user design has to be
+  added)
+
 `modules` : Different modules needed for the main script.
 
 `upload_bitstream` : Contains a script to upload a bitstream

--- a/software/README.md
+++ b/software/README.md
@@ -23,6 +23,10 @@ using the UART protocol.
 `board.py` : The main script which provides functionality to interact with the
 board. Described in detail below.
 
+> [!NOTE]
+You can find a checklist for things that have to be considered when uploading a
+bitstream [here](../doc/setup_checklist.md).
+
 ## Board CLI
 
 The main functionality of `board.py` is uploading a bitstream over UART to the

--- a/software/board.py
+++ b/software/board.py
@@ -95,7 +95,8 @@ def setup_parser() -> argparse.Namespace:
     upload_parser.add_argument(
         "-b",
         "--baudrate",
-        help="Specifies the baudrate. Defaults to 57600 which is the eFPGAs baud rate at 10 MHz.",
+        help="Specifies the baudrate. Defaults to 57600 which is the baud rate"
+        + " of MPW-2 at 10 MHz and of MPW-5 at 12.5 MHz.",
         type=int,
         default=57600,
     )


### PR DESCRIPTION
This adds a checklist for the board setup and also fixes some minor issues in the docs such as:
  - Improve the help message of the baudrate parameter in `board.py`
  - Fix the alert in `software/README.md` so it is displayed correctly
  - Add the fabric directory in `software/README.md`